### PR TITLE
Allow loading documents by relationship and externalId

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 "use strict";
 
 const pgClient = require("./lib/client");
-const crud = require("./lib/query");
+const query = require("./lib/query");
 const initDb = require("./lib/init-db");
 const testHelper = require("./lib/testHelper");
 
 module.exports = {
-  crud,
+  query,
   pgClient,
   initDb,
   testHelper

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const pgClient = require("./lib/client");
-const crud = require("./lib/crud");
+const crud = require("./lib/query");
 const initDb = require("./lib/init-db");
 const testHelper = require("./lib/testHelper");
 

--- a/lib/crud.js
+++ b/lib/crud.js
@@ -33,6 +33,40 @@ function load(id, force, cb) {
   });
 }
 
+function loadByRelationship(entityType, relationType, id, cb) {
+  const q = [
+    "SELECT doc",
+    "FROM entity e, entity_version ev",
+    "WHERE e.latest_version_id = ev.version_id",
+    "AND e.entity_type = $1",
+    "AND ev.doc -> 'relationships' @> $2"
+  ];
+
+  pgClient.query(q.join(" "), [entityType, `[{"type": "${relationType}", "id": "${id}"}]`], (err, res) => {
+    if (err) return cb(err);
+    const entity = (res.rows && res.rows.length > 0) ? res.rows[0] : null;
+    const doc = (entity !== null) ? entity.doc : null;
+    return cb(null, doc);
+  });
+}
+
+function loadByExternalId(entityType, externalIdType, id, cb) {
+  const q = [
+    "SELECT doc",
+    "FROM entity e, entity_version ev",
+    "WHERE e.latest_version_id = ev.version_id",
+    "AND e.entity_type = $1",
+    "AND ev.doc -> 'externalIds' @> $2"
+  ];
+
+  pgClient.query(q.join(" "), [entityType, `{"${externalIdType}": "${id}"}`], (err, res) => {
+    if (err) return cb(err);
+    const entity = (res.rows && res.rows.length > 0) ? res.rows[0] : null;
+    const doc = (entity !== null) ? entity.doc : null;
+    return cb(null, doc);
+  });
+}
+
 function remove(id, cb) {
   const q = ["UPDATE entity",
     "SET entity_removed = now()",
@@ -173,6 +207,8 @@ function insertVersion(entity, done) {
 
 module.exports = {
   load,
+  loadByRelationship,
+  loadByExternalId,
   loadVersion,
   listVersions,
   remove,

--- a/lib/crud.js
+++ b/lib/crud.js
@@ -39,11 +39,13 @@ function loadByRelationship(entityType, relationType, id, cb) {
     "FROM entity e, entity_version ev",
     "WHERE e.latest_version_id = ev.version_id",
     "AND e.entity_type = $1",
-    "AND ev.doc -> 'relationships' @> $2"
+    "AND ev.doc -> 'relationships' @> $2",
+    "AND e.entity_removed IS NULL"
   ];
 
   pgClient.query(q.join(" "), [entityType, `[{"type": "${relationType}", "id": "${id}"}]`], (err, res) => {
     if (err) return cb(err);
+    if (res.rows && res.rows.length > 1) return cb(new Error("Found more than one document"));
     const entity = (res.rows && res.rows.length > 0) ? res.rows[0] : null;
     const doc = (entity !== null) ? entity.doc : null;
     return cb(null, doc);
@@ -56,11 +58,13 @@ function loadByExternalId(entityType, externalIdType, id, cb) {
     "FROM entity e, entity_version ev",
     "WHERE e.latest_version_id = ev.version_id",
     "AND e.entity_type = $1",
-    "AND ev.doc -> 'externalIds' @> $2"
+    "AND ev.doc -> 'externalIds' @> $2",
+    "AND e.entity_removed IS NULL"
   ];
 
   pgClient.query(q.join(" "), [entityType, `{"${externalIdType}": "${id}"}`], (err, res) => {
     if (err) return cb(err);
+    if (res.rows && res.rows.length > 1) return cb(new Error("Found more than one document"));
     const entity = (res.rows && res.rows.length > 0) ? res.rows[0] : null;
     const doc = (entity !== null) ? entity.doc : null;
     return cb(null, doc);

--- a/lib/query.js
+++ b/lib/query.js
@@ -33,7 +33,7 @@ function load(id, force, cb) {
   });
 }
 
-function loadByRelationship(entityType, relationType, id, cb) {
+function queryByRelationship(entityType, relationType, id, cb) {
   const q = [
     "SELECT doc",
     "FROM entity e, entity_version ev",
@@ -45,14 +45,15 @@ function loadByRelationship(entityType, relationType, id, cb) {
 
   pgClient.query(q.join(" "), [entityType, `[{"type": "${relationType}", "id": "${id}"}]`], (err, res) => {
     if (err) return cb(err);
-    if (res.rows && res.rows.length > 1) return cb(new Error("Found more than one document"));
-    const entity = (res.rows && res.rows.length > 0) ? res.rows[0] : null;
-    const doc = (entity !== null) ? entity.doc : null;
-    return cb(null, doc);
+    let docs = [];
+    if (res.rows && res.rows.length > 0) {
+      docs = res.rows.map((entity) => entity.doc);
+    }
+    return cb(null, docs);
   });
 }
 
-function loadByExternalId(entityType, externalIdType, id, cb) {
+function loadByExternalId(entityType, systemName, externalIdType, id, cb) {
   const q = [
     "SELECT doc",
     "FROM entity e, entity_version ev",
@@ -62,7 +63,7 @@ function loadByExternalId(entityType, externalIdType, id, cb) {
     "AND e.entity_removed IS NULL"
   ];
 
-  pgClient.query(q.join(" "), [entityType, `{"${externalIdType}": "${id}"}`], (err, res) => {
+  pgClient.query(q.join(" "), [entityType, `{"${systemName}": {"${externalIdType}": "${id}"}}`], (err, res) => {
     if (err) return cb(err);
     if (res.rows && res.rows.length > 1) return cb(new Error("Found more than one document"));
     const entity = (res.rows && res.rows.length > 0) ? res.rows[0] : null;
@@ -211,7 +212,7 @@ function insertVersion(entity, done) {
 
 module.exports = {
   load,
-  loadByRelationship,
+  queryByRelationship,
   loadByExternalId,
   loadVersion,
   listVersions,

--- a/lib/testHelper.js
+++ b/lib/testHelper.js
@@ -6,7 +6,7 @@ const async = require("async");
 const initDb = require("./init-db");
 const {
   tables
-} = require("./crud");
+} = require("./query");
 
 // NOTE: database will be dropped and recreated in each test case.
 // If this becomes a performance problem, use some sort of global

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-doc-store",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "Linus Thiel",
     "Markus Ekholm"
   ],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "pretest": "docker-compose build",
     "test": "node_modules/.bin/mocha",

--- a/test/feature/entity-feature.js
+++ b/test/feature/entity-feature.js
@@ -230,4 +230,34 @@ Feature("Entity", () => {
       savedEntity.should.deep.eql(entity);
     });
   });
+
+  Scenario("Loading docs with ambiguous relation", () => {
+    const otherEntity = Object.assign({}, entity, {id: uuid.v4()});
+
+    before((done) => {
+      helper.clearAndInit(done);
+    });
+
+    Given("that there are two entities in the db with the same relation", (done) => {
+      crud.upsert(entity, (err) => {
+        if (err) return done(err);
+        crud.upsert(otherEntity, done);
+      });
+    });
+
+    let error, savedEntity;
+    When("we try to load ONE of them by relationship", (done) => {
+      const rel = entity.relationships[0];
+      crud.loadByRelationship(entity.type, rel.type, rel.id, (err, dbEntity) => {
+        error = err;
+        savedEntity = dbEntity;
+        return done();
+      });
+    });
+
+    Then("an error should be thrown", () => {
+      error.should.be.an("error");
+      should.equal(savedEntity, undefined);
+    });
+  });
 });

--- a/test/feature/entity-feature.js
+++ b/test/feature/entity-feature.js
@@ -2,7 +2,7 @@
 
 /* eslint no-undef: 0, new-cap: 0 */
 
-const crud = require("../../lib/crud");
+const query = require("../../lib/query");
 const uuid = require("uuid");
 const helper = require("../../lib/testHelper");
 
@@ -27,8 +27,12 @@ Feature("Entity", () => {
       }
     ],
     externalIds: {
-      "externalIdType": "external.id",
-      "otherExternalIdType": "other.external.id"
+      "system": {
+        "type": "externalId"
+      },
+      "other.system": {
+        "other.type": "otherExternalId"
+      }
     }
   };
 
@@ -41,11 +45,11 @@ Feature("Entity", () => {
     let savedEntity;
 
     Given("a new entity is saved", (done) => {
-      crud.upsert(entity, done);
+      query.upsert(entity, done);
     });
 
     When("we load it", (done) => {
-      crud.load(entity.id, (err, dbEntity) => {
+      query.load(entity.id, (err, dbEntity) => {
         if (err) return done(err);
         savedEntity = dbEntity;
         return done();
@@ -66,15 +70,15 @@ Feature("Entity", () => {
     });
 
     Given("a new entity is saved", (done) => {
-      crud.upsert(entity, done);
+      query.upsert(entity, done);
     });
 
     When("we delete it", (done) => {
-      crud.remove(entity.id, done);
+      query.remove(entity.id, done);
     });
 
     Then("it should not be possible to load without force", (done) => {
-      crud.load(entity.id, (err, dbEntity) => {
+      query.load(entity.id, (err, dbEntity) => {
         if (err) return done(err);
         should.equal(dbEntity, null);
         return done();
@@ -90,18 +94,18 @@ Feature("Entity", () => {
     });
 
     Given("a new entity is saved", (done) => {
-      crud.upsert(entity, done);
+      query.upsert(entity, done);
     });
 
     When("we delete it", (done) => {
-      crud.remove(entity.id, (err) => {
+      query.remove(entity.id, (err) => {
         if (err) return done(err);
         return done();
       });
     });
 
     Then("we load it with force", (done) => {
-      crud.load(entity.id, true, (err, dbEntity) => {
+      query.load(entity.id, true, (err, dbEntity) => {
         if (err) return done(err);
         savedEntity = dbEntity;
         return done();
@@ -122,18 +126,18 @@ Feature("Entity", () => {
     });
 
     Given("a new entity is saved", (done) => {
-      crud.upsert(entity, done);
+      query.upsert(entity, done);
     });
 
     And("we delete it", (done) => {
-      crud.remove(entity.id, (err) => {
+      query.remove(entity.id, (err) => {
         if (err) return done(err);
         return done();
       });
     });
 
     Then("it should not be possible to update the entity", (done) => {
-      crud.upsert(entity, (err, res) => {
+      query.upsert(entity, (err, res) => {
         if (err) return done(err);
         res.wasConflict.should.eql(true);
         return done();
@@ -147,11 +151,11 @@ Feature("Entity", () => {
     });
 
     Given("that there is an entity in the db", (done) => {
-      crud.upsert(entity, done);
+      query.upsert(entity, done);
     });
 
     And("we remove the entity", (done) => {
-      crud.remove(entity.id, (err, res) => {
+      query.remove(entity.id, (err, res) => {
         if (err) return done(err);
         should.equal(res.removed, entity.id);
         return done();
@@ -159,7 +163,7 @@ Feature("Entity", () => {
     });
 
     When("we try to remove it again nothing is removed", (done) => {
-      crud.remove(entity.id, (err, res) => {
+      query.remove(entity.id, (err, res) => {
         if (err) return done(err);
         should.equal(res.removed, null);
         return done();
@@ -174,7 +178,7 @@ Feature("Entity", () => {
     });
 
     When("We remove an entity that never existed we should have removed nothing.", (done) => {
-      crud.remove(entity.id, (err, res) => {
+      query.remove(entity.id, (err, res) => {
         if (err) return done(err);
         should.equal(res.removed, null);
         return done();
@@ -183,27 +187,58 @@ Feature("Entity", () => {
   });
 
   Scenario("Get entity by relationship", () => {
-    let savedEntity;
+    let savedEntities;
 
     before((done) => {
       helper.clearAndInit(done);
     });
 
     Given("that there is an entity in the db", (done) => {
-      crud.upsert(entity, done);
+      query.upsert(entity, done);
     });
 
     When("we try to load it by relationship", (done) => {
       const rel = entity.relationships[0];
-      crud.loadByRelationship(entity.type, rel.type, rel.id, (err, dbEntity) => {
+      query.queryByRelationship(entity.type, rel.type, rel.id, (err, dbEntities) => {
         if (err) return done(err);
-        savedEntity = dbEntity;
+        savedEntities = dbEntities;
         return done();
       });
     });
 
     Then("it should be found and match the one upserted", () => {
-      savedEntity.should.deep.eql(entity);
+      savedEntities.length.should.equal(1);
+      savedEntities[0].should.deep.equal(entity);
+    });
+  });
+
+  Scenario("Get multiple entities by relationship", () => {
+    const otherEntity = Object.assign({}, entity, {id: uuid.v4()});
+    let savedEntities;
+
+    before((done) => {
+      helper.clearAndInit(done);
+    });
+
+    Given("that there TWO entities in the db", (done) => {
+      query.upsert(entity, (err) => {
+        if (err) return done(err);
+        query.upsert(otherEntity, done);
+      });
+    });
+
+    When("we try to load them by relationship", (done) => {
+      const rel = entity.relationships[0];
+      query.queryByRelationship(entity.type, rel.type, rel.id, (err, dbEntities) => {
+        if (err) return done(err);
+        savedEntities = dbEntities;
+        return done();
+      });
+    });
+
+    Then("it should be found and match the one upserted", () => {
+      savedEntities.length.should.equal(2);
+      savedEntities.should.have.deep.members([entity, otherEntity]);
     });
   });
 
@@ -215,11 +250,11 @@ Feature("Entity", () => {
     });
 
     Given("that there is an entity in the db", (done) => {
-      crud.upsert(entity, done);
+      query.upsert(entity, done);
     });
 
     When("we try to load it by externalId", (done) => {
-      crud.loadByExternalId(entity.type, "externalIdType", "external.id", (err, dbEntity) => {
+      query.loadByExternalId(entity.type, "system", "type", "externalId", (err, dbEntity) => {
         if (err) return done(err);
         savedEntity = dbEntity;
         return done();
@@ -231,24 +266,23 @@ Feature("Entity", () => {
     });
   });
 
-  Scenario("Loading docs with ambiguous relation", () => {
+  Scenario("Loading docs with ambiguous externalId", () => {
     const otherEntity = Object.assign({}, entity, {id: uuid.v4()});
 
     before((done) => {
       helper.clearAndInit(done);
     });
 
-    Given("that there are two entities in the db with the same relation", (done) => {
-      crud.upsert(entity, (err) => {
+    Given("that there are two entities in the db with the same externalId", (done) => {
+      query.upsert(entity, (err) => {
         if (err) return done(err);
-        crud.upsert(otherEntity, done);
+        query.upsert(otherEntity, done);
       });
     });
 
     let error, savedEntity;
-    When("we try to load ONE of them by relationship", (done) => {
-      const rel = entity.relationships[0];
-      crud.loadByRelationship(entity.type, rel.type, rel.id, (err, dbEntity) => {
+    When("we try to load ONE of them by externalId", (done) => {
+      query.loadByExternalId(entity.type, "system", "type", "externalId", (err, dbEntity) => {
         error = err;
         savedEntity = dbEntity;
         return done();

--- a/test/feature/entity-feature.js
+++ b/test/feature/entity-feature.js
@@ -13,6 +13,22 @@ Feature("Entity", () => {
     type: "person",
     attributes: {
       name: "J Doe"
+    },
+    relationships: [
+      {
+        "system": "system.name",
+        "type": "foreign.type",
+        "id": "type.guid"
+      },
+      {
+        "system": "other.system.name",
+        "type": "other.foreign.type",
+        "id": "other.type.guid"
+      }
+    ],
+    externalIds: {
+      "externalIdType": "external.id",
+      "otherExternalIdType": "other.external.id"
     }
   };
 
@@ -163,6 +179,55 @@ Feature("Entity", () => {
         should.equal(res.removed, null);
         return done();
       });
+    });
+  });
+
+  Scenario("Get entity by relationship", () => {
+    let savedEntity;
+
+    before((done) => {
+      helper.clearAndInit(done);
+    });
+
+    Given("that there is an entity in the db", (done) => {
+      crud.upsert(entity, done);
+    });
+
+    When("we try to load it by relationship", (done) => {
+      const rel = entity.relationships[0];
+      crud.loadByRelationship(entity.type, rel.type, rel.id, (err, dbEntity) => {
+        if (err) return done(err);
+        savedEntity = dbEntity;
+        return done();
+      });
+    });
+
+    Then("it should be found and match the one upserted", () => {
+      savedEntity.should.deep.eql(entity);
+    });
+  });
+
+  Scenario("Get entity by externalId", () => {
+    let savedEntity;
+
+    before((done) => {
+      helper.clearAndInit(done);
+    });
+
+    Given("that there is an entity in the db", (done) => {
+      crud.upsert(entity, done);
+    });
+
+    When("we try to load it by externalId", (done) => {
+      crud.loadByExternalId(entity.type, "externalIdType", "external.id", (err, dbEntity) => {
+        if (err) return done(err);
+        savedEntity = dbEntity;
+        return done();
+      });
+    });
+
+    Then("it should be found and match the one upserted", () => {
+      savedEntity.should.deep.eql(entity);
     });
   });
 });

--- a/test/feature/version-feature.js
+++ b/test/feature/version-feature.js
@@ -2,7 +2,7 @@
 
 /* eslint no-undef: 0, new-cap: 0 */
 
-const crud = require("../../lib/crud");
+const crud = require("../../lib/query");
 const uuid = require("uuid");
 const helper = require("../../lib/testHelper");
 


### PR DESCRIPTION
Documents can now be loaded using a _relationships_ or _externalIds_ value.