### PR TITLE
Possibility to restore a removed document

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Purpose and features
 Opionated solution for storing documents as entities in postgres
 without an ORM-solution. This package aims to use postgres as a
-document store (storing json data as documents) but with the benefits
+document store (storing JSON data as documents) but with the benefits
 of Postgres as a platform and with the occasional use of SQL features
 such as referential integrity between identifiers.
 
@@ -41,9 +41,21 @@ db.load(id, (dbErr, entity) => {
 
 ### (Soft) remove a document
 ```js
-db.remove(id, (dbErr, res) => {
+db.remove(id, (dbErr) => {
   if (dbErr) return dbErr;
-  // res.removed will contain the id if there was an entity to remove
+  // this will mark the entity as removed and add an empty version as
+  // the last version
+});
+
+```
+
+### Restore a version of a document
+```js
+db.restore(versionId, (dbErr, entity) => {
+  if (dbErr) return dbErr;
+  // this will make versionId the last version of the entity to which
+  // it belongs and unmark the entity as removed (as there is an
+  // explicit call to restore the version)
 });
 
 ```
@@ -51,12 +63,19 @@ db.remove(id, (dbErr, res) => {
 ## Versions
 All updates uses upsert and stores updates to an existing entity as a
 new version in the entity\_version table. The entity table contains a
-reference to the latest version. Attributes are stored in the
-entity\_version table, i.e. the attributes column contains a specific
+reference to the latest version. The document is stored in the
+entity\_version table, i.e. the doc column contains a specific
 version of the JSON document.
 
 ## (Soft) removal
 A document can be marked as removed. A document and its' versions will
 no longer be listed of read using the load and list functions, unless
 the second argument is set to true (force). It is not possible to
-upsert a removed document (it will be considered a conflict).
+upsert a removed document (it will be considered a conflict). Removing
+a document adds an empty document as the latest version of the entity
+(for traceability).
+
+It is possible to un-remove a document by restoring it to a specific
+version, this will create a new (latest) version of the document using
+the data from the specified version. This also marks the document as
+not removed.

--- a/lib/query.js
+++ b/lib/query.js
@@ -72,14 +72,64 @@ function loadByExternalId(entityType, systemName, externalIdType, id, cb) {
   });
 }
 
-function remove(id, cb) {
-  const q = ["UPDATE entity",
-    "SET entity_removed = now()",
-    "WHERE entity_id = $1 AND entity_removed IS NULL"];
-  pgClient.query(q.join(" "), [id], (err, res) => {
+function remove(id, correlationId, cb) {
+  if (typeof correlationId === "function") {
+    cb = correlationId;
+    correlationId = null;
+  }
+
+  load(id, (err, doc) => {
     if (err) return cb(err);
-    if (res.rowCount === 0) return cb(null, {removed: null});
-    return cb(null, {removed: id});
+    if (!doc) return cb(new Error("no such entity"));
+
+    const emptyDoc = {
+      id: id,
+      type: doc.type,
+      meta: {correlationId: correlationId}
+    };
+
+    return upsert(emptyDoc, (upsertErr) => {
+      if (upsertErr) return cb(upsertErr);
+      const q = [
+        "UPDATE entity",
+        "SET entity_removed = now()",
+        "WHERE entity_id = $1 AND entity_removed IS NULL"];
+      return pgClient.query(q.join(" "), [id], (rmErr, res) => {
+        if (rmErr) return cb(rmErr);
+        if (res.rowCount === 0) return cb(new Error("Could not remove"));
+        return cb(null);
+      });
+    });
+  });
+}
+
+function restoreVersion(versionId, correlationId, cb) {
+  if (typeof correlationId === "function") {
+    cb = correlationId;
+    correlationId = null;
+  }
+
+  loadVersion(versionId, true, (err, res) => {
+    if (err) return cb(err);
+
+    const entity = res.entity;
+    entity.meta.correlationId = correlationId;
+
+    return maybeUnRemove(entity.id, (unremoveErr) => {
+      if (unremoveErr) return cb(unremoveErr);
+      return upsert(entity, cb);
+    });
+  });
+}
+
+function maybeUnRemove(id, cb) {
+  const q = [
+    "UPDATE entity",
+    "SET entity_removed = null",
+    "WHERE entity_id = $1"];
+  pgClient.query(q.join(" "), [id], (err) => {
+    if (err) return cb(err);
+    return cb(null);
   });
 }
 
@@ -217,6 +267,7 @@ module.exports = {
   loadVersion,
   listVersions,
   remove,
+  restoreVersion,
   upsert,
   tables
 };

--- a/lib/query.js
+++ b/lib/query.js
@@ -93,7 +93,7 @@ function remove(id, correlationId, cb) {
       const q = [
         "UPDATE entity",
         "SET entity_removed = now()",
-        "WHERE entity_id = $1 AND entity_removed IS NULL"];
+        "WHERE entity_id = $1"];
       return pgClient.query(q.join(" "), [id], (rmErr, res) => {
         if (rmErr) return cb(rmErr);
         if (res.rowCount === 0) return cb(new Error("Could not remove"));

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "Linus Thiel",
     "Markus Ekholm"
   ],
-  "version": "1.4.1",
+  "version": "2.0.0",
   "scripts": {
     "pretest": "docker-compose build",
     "test": "node_modules/.bin/mocha",

--- a/test/feature/version-feature.js
+++ b/test/feature/version-feature.js
@@ -11,7 +11,8 @@ Feature("Version", () => {
   const attributes = [
     { name: "J Doe 1" },
     { name: "J Doe 2" },
-    { name: "J Doe 3" }
+    { name: "J Doe 3" },
+    undefined
   ];
 
   const entity = {
@@ -19,7 +20,7 @@ Feature("Version", () => {
     type: "person"
   };
 
-  const correlationIds = ["x", "y"];
+  const correlationIds = ["x", "y", "z", "ao"];
 
   Scenario("Save and load multiple versions of an entity", () => {
 
@@ -138,7 +139,9 @@ Feature("Version", () => {
   Scenario("Save, remove and forcefully load multiple versions of an entity", () => {
     let entityVersions;
     let versionNrTwoId;
+    let versionNrFourId;
     let versionNrTwo;
+    let versionNrFour;
 
     before((done) => {
       helper.clearAndInit(done);
@@ -146,23 +149,24 @@ Feature("Version", () => {
 
     Given("a new entity is saved", (done) => {
       entity.attributes = attributes[0];
-      crud.upsert(entity, done);
-    });
-
-    And("a new version is added to the entity", (done) => {
-      entity.attributes = attributes[1];
       entity.meta = { correlationId: correlationIds[0] };
       crud.upsert(entity, done);
     });
 
-    And("another version is added", (done) => {
-      entity.attributes = attributes[2];
+    And("a second version is added to the entity", (done) => {
+      entity.attributes = attributes[1];
       entity.meta = { correlationId: correlationIds[1] };
       crud.upsert(entity, done);
     });
 
-    When("we remove the entity", (done) => {
-      crud.remove(entity.id, done);
+    And("a third version is added", (done) => {
+      entity.attributes = attributes[2];
+      entity.meta = { correlationId: correlationIds[2] };
+      crud.upsert(entity, done);
+    });
+
+    And("we remove the entity", (done) => {
+      crud.remove(entity.id, correlationIds[3], done);
     });
 
     When("we forcefully get all the versions", (done) => {
@@ -173,29 +177,182 @@ Feature("Version", () => {
       });
     });
 
-    Then("it should return all added versions", () => {
-      entityVersions.should.have.lengthOf(3);
-      entityVersions[1].correlationId.should.equal(correlationIds[0]);
+    Then("it should have return all added versions", () => {
+      entityVersions.should.have.lengthOf(4);
+      entityVersions[0].correlationId.should.equal(correlationIds[0]);
+      entityVersions[1].correlationId.should.equal(correlationIds[1]);
+      entityVersions[2].correlationId.should.equal(correlationIds[2]);
+      entityVersions[3].correlationId.should.equal(correlationIds[3]);
     });
 
-    Given("the returned version id of the second version", () => {
+    And("forcefully fetching the second version, it should have all attributes saved in that version", (done) => {
       versionNrTwoId = entityVersions[1].versionId;
-    });
-
-    When("we forcefully fetch the second version", (done) => {
       crud.loadVersion(versionNrTwoId, true, (err, dbEntity) => {
         if (err) return done(err);
         versionNrTwo = dbEntity;
+        versionNrTwo.versionId.should.equal(versionNrTwoId);
+        versionNrTwo.entity.attributes.should.eql(attributes[1]);
+        versionNrTwo.correlationId.should.eql(correlationIds[1]);
         return done();
       });
     });
 
-    Then("it should have the attributes that was saved in that version", () => {
-      versionNrTwo.versionId.should.equal(versionNrTwoId);
-      versionNrTwo.entity.attributes.should.eql(attributes[1]);
-      versionNrTwo.correlationId.should.eql(correlationIds[0]);
+    And("forcefully fetching the fourth (last) version, it should have no attributes as it is the empty (removed) version", (done) => {
+      versionNrFourId = entityVersions[3].versionId;
+      crud.loadVersion(versionNrFourId, true, (err, dbEntity) => {
+        if (err) return done(err);
+        versionNrFour = dbEntity;
+        should.equal(versionNrFour.entity.attributes, attributes[3]);
+        versionNrFour.correlationId.should.equal(correlationIds[3]);
+        return done();
+      });
     });
   });
 
+  Scenario("Save, remove and restore a version of an entity", () => {
+    let entityVersions;
+    let restoredVersion;
+    let restoredEntity;
+
+    before((done) => {
+      helper.clearAndInit(done);
+    });
+
+    Given("a new entity is saved", (done) => {
+      entity.attributes = attributes[0];
+      entity.meta = { correlationId: correlationIds[0] };
+      crud.upsert(entity, done);
+    });
+
+    And("a second version is added to the entity", (done) => {
+      entity.attributes = attributes[1];
+      entity.meta = { correlationId: correlationIds[1] };
+      crud.upsert(entity, done);
+    });
+
+    And("we remove the entity", (done) => {
+      crud.remove(entity.id, correlationIds[2], done);
+    });
+
+    And("we forcefully get all the versions", (done) => {
+      crud.listVersions(entity.id, true, (err, dbEntity) => {
+        if (err) return done(err);
+        entityVersions = dbEntity;
+        return done();
+      });
+    });
+
+    When("we restore the second version", (done) => {
+      crud.restoreVersion(entityVersions[1].versionId, correlationIds[3], (err, res) => {
+        if (err) return done(err);
+        restoredVersion = res.versionId;
+        return done();
+      });
+    });
+
+    Then("the restored vesion should equal the second version, except correlationId and versionId", (done) => {
+      crud.loadVersion(restoredVersion, (err, res) => {
+        if (err) return done(err);
+        restoredEntity = res.entity;
+        res.correlationId.should.equal(correlationIds[3]);
+        res.versionId.should.equal(restoredVersion);
+        restoredVersion.should.not.equal(entityVersions[1].versionId);
+        restoredEntity.id.should.equal(entity.id);
+        restoredEntity.type.should.equal(entity.type);
+        restoredEntity.attributes.should.eql(entity.attributes);
+        return done();
+      });
+    });
+
+    And("there should be a total of four versions", (done) => {
+      crud.listVersions(entity.id, (err, dbEntity) => {
+        if (err) return done(err);
+        dbEntity.length.should.equal(4);
+        return done();
+      });
+    });
+
+    And("the last version should be the restored version", (done) => {
+      crud.load(entity.id, (err, dbEntity) => {
+        if (err) return done(err);
+        dbEntity.should.eql(restoredEntity);
+        return done();
+      });
+    });
+  });
+
+  Scenario("Save some versions and restore a previous version of an entity", () => {
+    let entityVersions;
+    let restoredVersion;
+    let restoredEntity;
+
+    before((done) => {
+      helper.clearAndInit(done);
+    });
+
+    Given("a new entity is saved", (done) => {
+      entity.attributes = attributes[0];
+      entity.meta = { correlationId: correlationIds[0] };
+      crud.upsert(entity, done);
+    });
+
+    And("a second version is added to the entity", (done) => {
+      entity.attributes = attributes[1];
+      entity.meta = { correlationId: correlationIds[1] };
+      crud.upsert(entity, done);
+    });
+
+    And("a third version is added to the entity", (done) => {
+      entity.attributes = attributes[2];
+      entity.meta = { correlationId: correlationIds[2] };
+      crud.upsert(entity, done);
+    });
+
+    And("we get all the versions", (done) => {
+      crud.listVersions(entity.id, (err, dbEntity) => {
+        if (err) return done(err);
+        entityVersions = dbEntity;
+        return done();
+      });
+    });
+
+    When("we restore the second version", (done) => {
+      crud.restoreVersion(entityVersions[1].versionId, correlationIds[3], (err, res) => {
+        if (err) return done(err);
+        restoredVersion = res.versionId;
+        return done();
+      });
+    });
+
+    Then("the restored vesion should equal the second version, except correlationId and versionId", (done) => {
+      crud.loadVersion(restoredVersion, (err, res) => {
+        if (err) return done(err);
+        restoredEntity = res.entity;
+        res.correlationId.should.equal(correlationIds[3]);
+        res.versionId.should.equal(restoredVersion);
+        restoredVersion.should.not.equal(entityVersions[1].versionId);
+        restoredEntity.id.should.equal(entity.id);
+        restoredEntity.type.should.equal(entity.type);
+        restoredEntity.attributes.should.eql(attributes[1]);
+        return done();
+      });
+    });
+
+    And("there should be a total of four versions", (done) => {
+      crud.listVersions(entity.id, (err, dbEntity) => {
+        if (err) return done(err);
+        dbEntity.length.should.equal(4);
+        return done();
+      });
+    });
+
+    And("the last version should be the restored version", (done) => {
+      crud.load(entity.id, (err, dbEntity) => {
+        if (err) return done(err);
+        dbEntity.should.eql(restoredEntity);
+        return done();
+      });
+    });
+  });
 
 });


### PR DESCRIPTION
* (Soft) removing a document creates a empty version as the latest
  version (possible to list using force).
* Added possibility to specify correlation id when removing (added to
  the empty version specified above).
* Added possibility to restore an entity to a specific version. This
  will create a copy of the version and put it as the latest version.
  This will also remove the soft remove of the entity.
* Changed the behaviour of the remove function, the cb only takes an
  err, not a res. The error will be raised if no such entity exists.
* The changed behaviour a breaking API change and thus the major
  version has been bumped.