### PR TITLE
Allow querying single entities by relationship

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -33,7 +33,7 @@ function load(id, force, cb) {
   });
 }
 
-function queryByRelationship(entityType, relationType, id, cb) {
+function queryByRelationship(options, cb) {
   const q = [
     "SELECT doc",
     "FROM entity e, entity_version ev",
@@ -43,17 +43,51 @@ function queryByRelationship(entityType, relationType, id, cb) {
     "AND e.entity_removed IS NULL"
   ];
 
-  pgClient.query(q.join(" "), [entityType, `[{"type": "${relationType}", "id": "${id}"}]`], (err, res) => {
+  if (!options.entityType || !options.relationType || !options.id) {
+    return cb(new Error(`Missing parameters in queryByRelationship: ${JSON.stringify(options)}`));
+  }
+
+  pgClient.query(q.join(" "), [options.entityType, `[{"type": "${options.relationType}", "id": "${options.id}"}]`], (err, res) => {
     if (err) return cb(err);
     let docs = [];
     if (res.rows && res.rows.length > 0) {
       docs = res.rows.map((entity) => entity.doc);
+    } else if (options.errorOnNotFound === true) {
+      return cb(new Error(`DOC_NOT_FOUND: No document found using options: ${JSON.stringify(options)}`));
     }
     return cb(null, docs);
   });
 }
 
-function loadByExternalId(entityType, systemName, externalIdType, id, cb) {
+function queryBySingleRelationship(options, cb) {
+  const q = [
+    "SELECT doc",
+    "FROM entity e, entity_version ev",
+    "WHERE e.latest_version_id = ev.version_id",
+    "AND e.entity_type = $1",
+    "AND ev.doc -> 'relationships' @> $2",
+    "AND e.entity_removed IS NULL"
+  ];
+
+  if (!options.entityType || !options.relationType || !options.id) {
+    return cb(new Error(`Missing parameters in queryBySingleRelationship: ${JSON.stringify(options)}`));
+  }
+
+  pgClient.query(q.join(" "), [options.entityType, `[{"type": "${options.relationType}", "id": "${options.id}"}]`], (err, res) => {
+    if (err) return cb(err);
+    let doc = null;
+    if (res.rows && res.rows.length === 1) {
+      doc = res.rows[0].doc;
+    } else if (res.rows && res.rows.length > 1) {
+      return cb(new Error("Found more than one document"));
+    } else if (options.errorOnNotFound === true) {
+      return cb(new Error(`DOC_NOT_FOUND: No document found using options: ${JSON.stringify(options)}`));
+    }
+    return cb(null, doc);
+  });
+}
+
+function loadByExternalId(options, cb) {
   const q = [
     "SELECT doc",
     "FROM entity e, entity_version ev",
@@ -63,11 +97,20 @@ function loadByExternalId(entityType, systemName, externalIdType, id, cb) {
     "AND e.entity_removed IS NULL"
   ];
 
-  pgClient.query(q.join(" "), [entityType, `{"${systemName}": {"${externalIdType}": "${id}"}}`], (err, res) => {
+  if (!options.entityType || !options.systemName || !options.externalIdType || !options.id) {
+    return cb(new Error(`Missing parameters in loadByExternalId: ${JSON.stringify(options)}`));
+  }
+
+  pgClient.query(q.join(" "), [options.entityType, `{"${options.systemName}": {"${options.externalIdType}": "${options.id}"}}`], (err, res) => {
     if (err) return cb(err);
-    if (res.rows && res.rows.length > 1) return cb(new Error("Found more than one document"));
-    const entity = (res.rows && res.rows.length > 0) ? res.rows[0] : null;
-    const doc = (entity !== null) ? entity.doc : null;
+    let doc = null;
+    if (res.rows && res.rows.length === 1) {
+      doc = res.rows[0].doc;
+    } else if (res.rows && res.rows.length > 1) {
+      return cb(new Error("Found more than one document"));
+    } else if (options.errorOnNotFound === true) {
+      return cb(new Error(`DOC_NOT_FOUND: No document found using options: ${JSON.stringify(options)}`));
+    }
     return cb(null, doc);
   });
 }
@@ -213,6 +256,7 @@ function insertVersion(entity, done) {
 module.exports = {
   load,
   queryByRelationship,
+  queryBySingleRelationship,
   loadByExternalId,
   loadVersion,
   listVersions,

--- a/lib/query.js
+++ b/lib/query.js
@@ -60,30 +60,12 @@ function queryByRelationship(options, cb) {
 }
 
 function queryBySingleRelationship(options, cb) {
-  const q = [
-    "SELECT doc",
-    "FROM entity e, entity_version ev",
-    "WHERE e.latest_version_id = ev.version_id",
-    "AND e.entity_type = $1",
-    "AND ev.doc -> 'relationships' @> $2",
-    "AND e.entity_removed IS NULL"
-  ];
-
-  if (!options.entityType || !options.relationType || !options.id) {
-    return cb(new Error(`Missing parameters in queryBySingleRelationship: ${JSON.stringify(options)}`));
-  }
-
-  pgClient.query(q.join(" "), [options.entityType, `[{"type": "${options.relationType}", "id": "${options.id}"}]`], (err, res) => {
+  queryByRelationship(options, (err, docs) => {
     if (err) return cb(err);
-    let doc = null;
-    if (res.rows && res.rows.length === 1) {
-      doc = res.rows[0].doc;
-    } else if (res.rows && res.rows.length > 1) {
+    if (docs && docs.length > 1) {
       return cb(new Error("Found more than one document"));
-    } else if (options.errorOnNotFound === true) {
-      return cb(new Error(`DOC_NOT_FOUND: No document found using options: ${JSON.stringify(options)}`));
     }
-    return cb(null, doc);
+    return cb(null, docs[0] || null);
   });
 }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -63,7 +63,7 @@ function queryBySingleRelationship(options, cb) {
   queryByRelationship(options, (err, docs) => {
     if (err) return cb(err);
     if (docs && docs.length > 1) {
-      return cb(new Error("Found more than one document"));
+      return cb(new Error(`Found more than one document using options: ${JSON.stringify(options)}`));
     }
     return cb(null, docs[0] || null);
   });
@@ -89,7 +89,7 @@ function loadByExternalId(options, cb) {
     if (res.rows && res.rows.length === 1) {
       doc = res.rows[0].doc;
     } else if (res.rows && res.rows.length > 1) {
-      return cb(new Error("Found more than one document"));
+      return cb(new Error(`Found more than one document using options: ${JSON.stringify(options)}`));
     } else if (options.errorOnNotFound === true) {
       return cb(new Error(`DOC_NOT_FOUND: No document found using options: ${JSON.stringify(options)}`));
     }


### PR DESCRIPTION
- Allow querying single entities by relationship
- Options object as argument instead of parameter list
- Throw errors when no document found if enabled