### PR TITLE
Present and persist updatedAt and createdAt in meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ const entity = {
 db.upsert(entity, (dbErr, entity) => {
   if (dbErr) return dbErr;
   // entity.id will contain id, will be created with uuid.v4() if not set
+  // entity.meta.createdAt and entity.meta.updatedAt will be set/updated with
+  // the correct update and creation times. User supplied values for
+  // createdAt and updatedAt are ignored and overwritten.
 });
 ```
+
 ### Load a document
 ```js
 const db = require("pg-doc-store").crud;

--- a/config/test.json
+++ b/config/test.json
@@ -5,7 +5,7 @@
     "user": "et",
     "password": "ET",
     "host": "localhost",
-    "port": "5432",
+    "port": "5435",
     "database": "entity_test"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:9
     restart: always
     ports:
-      - "5432:5432"
+      - "5435:5432"
     environment:
       - POSTGRES_USER=et
       - POSTGRES_PASSWORD=ET

--- a/lib/query.js
+++ b/lib/query.js
@@ -17,7 +17,7 @@ function load(id, force, cb) {
   }
 
   const q = [
-    "SELECT doc",
+    "SELECT doc, created, entity_created, correlation_id",
     "FROM entity e, entity_version ev",
     "WHERE e.latest_version_id = ev.version_id AND e.entity_id = $1"
   ];
@@ -29,14 +29,14 @@ function load(id, force, cb) {
   pgClient.query(q.join(" "), [id], (err, res) => {
     if (err) return cb(err);
     const entity = (res.rows && res.rows.length > 0) ? res.rows[0] : null;
-    const doc = (entity !== null) ? entity.doc : null;
+    const doc = getDocWithMeta(entity);
     return cb(null, doc);
   });
 }
 
 function queryByRelationship(options, cb) {
   const q = [
-    "SELECT doc",
+    "SELECT doc, entity_created, created, correlation_id",
     "FROM entity e, entity_version ev",
     "WHERE e.latest_version_id = ev.version_id",
     "AND e.entity_type = $1",
@@ -57,12 +57,25 @@ function queryByRelationship(options, cb) {
     if (err) return cb(err);
     let docs = [];
     if (res.rows && res.rows.length > 0) {
-      docs = res.rows.map((entity) => entity.doc);
+      docs = res.rows.map(getDocWithMeta);
     } else if (options.errorOnNotFound === true) {
       return cb(new Error(`DOC_NOT_FOUND: No document found using options: ${JSON.stringify(options)}`));
     }
     return cb(null, docs);
   });
+}
+
+function getDocWithMeta(entity) {
+  const doc = (entity !== null) ? entity.doc : null;
+  if (doc) {
+    if (!doc.meta) doc.meta = {};
+    if (entity.correlation_id && !doc.meta.correlationId) doc.meta.correlationId = entity.correlation_id;
+    // override persisted value since previous versions used the faulty user supplied date
+    if (entity.entity_created) doc.meta.createdAt = entity.entity_created.toISOString();
+    // override persisted value since previous versions used the faulty user supplied date
+    if (entity.created) doc.meta.updatedAt = entity.created.toISOString();
+  }
+  return doc;
 }
 
 function queryBySingleRelationship(options, cb) {
@@ -77,7 +90,7 @@ function queryBySingleRelationship(options, cb) {
 
 function loadByExternalId(options, cb) {
   const q = [
-    "SELECT doc",
+    "SELECT doc, created, entity_created, correlation_id",
     "FROM entity e, entity_version ev",
     "WHERE e.latest_version_id = ev.version_id",
     "AND e.entity_type = $1",
@@ -97,7 +110,7 @@ function loadByExternalId(options, cb) {
     if (err) return cb(err);
     let doc = null;
     if (res.rows && res.rows.length === 1) {
-      doc = res.rows[0].doc;
+      doc = getDocWithMeta(res.rows[0]);
     } else if (res.rows && res.rows.length > 1) {
       return cb(new Error(`Found more than one document using options: ${JSON.stringify(options)}`));
     } else if (options.errorOnNotFound === true) {
@@ -127,7 +140,7 @@ function remove(id, correlationId, cb) {
       if (upsertErr) return cb(upsertErr);
       const q = [
         "UPDATE entity",
-        "SET entity_removed = now()",
+        "SET entity_removed = now() at time zone 'utc'",
         "WHERE entity_id = $1"];
       return pgClient.query(q.join(" "), [id], (rmErr, res) => {
         if (rmErr) return cb(rmErr);
@@ -176,7 +189,7 @@ function loadVersion(versionId, force, cb) {
   }
 
   const q = [
-    "SELECT ev.entity_id, created, doc, version_id, correlation_id",
+    "SELECT ev.entity_id, created, entity_created, doc, version_id, correlation_id",
     "FROM entity e, entity_version ev",
     "WHERE version_id = $1"
   ];
@@ -195,7 +208,7 @@ function loadVersion(versionId, force, cb) {
       created: v.created,
       versionId: v.version_id,
       correlationId: v.correlation_id,
-      entity: v.doc
+      entity: getDocWithMeta(v)
     };
 
     return cb(null, output);
@@ -243,9 +256,15 @@ function upsert(entity, done) {
 
 function upsertWithForce(entity, force, done) {
   entity.id = entity.id || uuid.v4();
+  if (!entity.meta) entity.meta = {};
+
   let newVersionId;
   async.waterfall([
-    (cb) => insertVersion(entity, force, cb),
+    (cb) => getEntityCreated(entity, cb),
+    (entityCreatedRes, cb) => {
+      const createdTimestamp = (entityCreatedRes.rows && entityCreatedRes.rows.length === 1) ? entityCreatedRes.rows[0].entity_created : undefined;
+      return insertVersion(entity, createdTimestamp, force, cb);
+    },
     (versionId, created, cb) => {
       if (versionId) {
         newVersionId = versionId;
@@ -253,7 +272,8 @@ function upsertWithForce(entity, force, done) {
       }
       return cb(null, {
         wasConflict: true,
-        oid: 0
+        oid: 0,
+        rows: []
       });
     }
   ], (err, upsertRes) => {
@@ -271,7 +291,7 @@ function doUpsert(entity, versionId, created, done) {
   pgClient.query([
     "INSERT into entity as e",
     "(entity_type, entity_id, entity_created, latest_version_id)",
-    "VALUES ($1::text, $2::text, $3::timestamp, $4::text)",
+    "VALUES ($1::text, $2::text, $3::timestamptz, $4::text)",
     "ON CONFLICT(entity_id) DO UPDATE",
     "SET latest_version_id=$4",
     "WHERE e.entity_id=$2"
@@ -280,14 +300,26 @@ function doUpsert(entity, versionId, created, done) {
   );
 }
 
-function insertVersion(entity, force, done) {
+function getEntityCreated(entity, done) {
+  pgClient.query([
+    "SELECT entity_created FROM entity WHERE entity_type = $1::text AND entity_id = $2::text",
+  ].join(" "), [entity.type, entity.id],
+  done
+  );
+}
+
+
+function insertVersion(entity, createdTimestamp, force, done) {
   const versionId = uuid.v4();
   const correlationId = (entity.meta && entity.meta.correlationId) || null;
+  const now = new Date().toISOString();
+  entity.meta.createdAt = createdTimestamp || now;
+  entity.meta.updatedAt = now;
 
   const q = [
     "INSERT into entity_version",
-    "(version_id, entity_id, correlation_id, doc)",
-    "SELECT $1::text, $2::text, $3::text, $4::jsonb"
+    "(version_id, entity_id, correlation_id, doc, created)",
+    "SELECT $1::text, $2::text, $3::text, $4::jsonb, $5::timestamptz"
   ];
 
   if (!force) {
@@ -295,7 +327,7 @@ function insertVersion(entity, force, done) {
   }
   q.push("RETURNING created");
 
-  pgClient.query(q.join(" "), [versionId, entity.id, correlationId, entity],
+  pgClient.query(q.join(" "), [versionId, entity.id, correlationId, entity, entity.meta.updatedAt],
     (err, res) => {
       const responseHasTimestamp = (!err && res && res.rows && res.rows.length === 1);
       const timestamp = responseHasTimestamp ? res.rows[0].created : undefined;

--- a/migrations/005-timestamp-with-tz.sql
+++ b/migrations/005-timestamp-with-tz.sql
@@ -1,0 +1,2 @@
+ALTER TABLE entity ALTER entity_created TYPE timestamptz USING entity_created AT TIME ZONE 'UTC', ALTER entity_removed TYPE timestamptz USING entity_removed AT TIME ZONE 'UTC', ALTER COLUMN entity_created SET DEFAULT now() at time zone 'utc';
+ALTER TABLE entity_version ALTER created TYPE timestamptz USING created AT TIME ZONE 'UTC', ALTER COLUMN created SET DEFAULT now() at time zone 'utc';

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "Markus Ekholm",
     "Ivan Malmberg"
   ],
-  "version": "2.3.3",
+  "version": "3.0.0",
   "scripts": {
     "test": "mocha",
     "posttest": "eslint --cache ."

--- a/test/feature/remove-feature.js
+++ b/test/feature/remove-feature.js
@@ -68,7 +68,13 @@ Feature("Clean version history for given entity", () => {
     And("the entity should have the latest attributes", (done) => {
       crud.load(entity.id, (err, anonymousEntity) => {
         if (err) return done(err);
-        anonymousEntity.should.eql(expectedEntity);
+        for (const key of Object.keys(expectedEntity)) {
+          if (key === "meta") {
+            anonymousEntity[key].correlationId.should.eql(entity[key].correlationId);
+          } else {
+            anonymousEntity[key].should.deep.equal(entity[key]);
+          }
+        }
         return done();
       });
     });
@@ -76,8 +82,12 @@ Feature("Clean version history for given entity", () => {
     And("the version should have the latest attributes", (done) => {
       crud.loadVersion(entityVersions[0].versionId, (err, res) => {
         if (err) return done(err);
-        res.entity.should.eql(expectedEntity);
+        for (const key of Object.keys(expectedEntity)) {
+          if (key === "meta") continue;
+          res.entity[key].should.deep.equal(entity[key]);
+        }
         res.correlationId.should.equal(correlationIds[2]);
+        res.entity.meta.correlationId.should.eql(correlationIds[2]);
         return done();
       });
     });
@@ -127,7 +137,13 @@ Feature("Clean version history for given entity", () => {
     And("the entity should have the latest attributes and only possible to fetch forcefully", (done) => {
       crud.load(entity.id, true, (err, anonymousEntity) => {
         if (err) return done(err);
-        anonymousEntity.should.eql(expectedEntity);
+        for (const key of Object.keys(expectedEntity)) {
+          if (key === "meta") {
+            anonymousEntity[key].correlationId.should.eql(entity[key].correlationId);
+          } else {
+            anonymousEntity[key].should.deep.equal(entity[key]);
+          }
+        }
         return done();
       });
     });
@@ -135,8 +151,12 @@ Feature("Clean version history for given entity", () => {
     And("the version should have the latest attributes and only possible to fetch forcefully", (done) => {
       crud.loadVersion(entityVersions[0].versionId, true, (err, res) => {
         if (err) return done(err);
-        res.entity.should.eql(expectedEntity);
+        for (const key of Object.keys(expectedEntity)) {
+          if (key === "meta") continue;
+          res.entity[key].should.deep.equal(entity[key]);
+        }
         res.correlationId.should.equal(correlationIds[2]);
+        res.entity.meta.correlationId.should.eql(correlationIds[2]);
         return done();
       });
     });

--- a/test/feature/version-feature.js
+++ b/test/feature/version-feature.js
@@ -26,6 +26,7 @@ Feature("Version", () => {
   Scenario("Save and load multiple versions of an entity", () => {
 
     let entityVersions;
+    let genesisEntity;
     let versionNrTwoId;
     let versionNrTwo;
 
@@ -36,6 +37,14 @@ Feature("Version", () => {
     Given("a new entity is saved", (done) => {
       entity.attributes = attributes[0];
       crud.upsert(entity, done);
+    });
+
+    And("we get the genesis version", (done) => {
+      crud.load(entity.id, (err, res) => {
+        if (err) return done(err);
+        genesisEntity = res;
+        done();
+      });
     });
 
     And("a new version is added to the entity", (done) => {
@@ -79,6 +88,13 @@ Feature("Version", () => {
       versionNrTwo.versionId.should.equal(versionNrTwoId);
       versionNrTwo.entity.attributes.should.eql(attributes[1]);
       versionNrTwo.correlationId.should.eql(correlationIds[0]);
+    });
+
+    And("it should have been updated after the genisys version but created at the same time", () => {
+      const updatedAt = new Date(versionNrTwo.entity.meta.updatedAt);
+      const createdAt = new Date(versionNrTwo.entity.meta.createdAt);
+      createdAt.should.eql(new Date(genesisEntity.meta.createdAt));
+      updatedAt.should.be.above(createdAt);
     });
   });
 


### PR DESCRIPTION
* When fetching a version or entity, populate entity.meta with
  updatedAt and createdAt based on entity_version created and entity
  entity_created as well as correlationId from entity_version
  correlation_id overriding persistd data in order to not display
  faulty dates for old objects persited with the user supplied
  createdAt and/or updatedAt.
* When upserting an entity, ignore user specified updatedAt and
  createdAt as they will not be used and set the actual updatedAt
  and createdAt on the supplied entity object before persisting.
  I.e. updatedAt = now and createdAt = now or when the entity was
  created if it already exists.
* Change all timestamp fields to use timestamp with tz
* Changed port for pg instance to 5435 to now clash with other running
  instances when testing.