### PR TITLE
Drop support for Node < 24

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v5
@@ -27,9 +27,7 @@ jobs:
         run: docker compose up --build -d postgres
 
       - name: Install dependencies
-        run: |
-          npm install -g npm@11.12.1
-          npm ci
+        run: npm ci
         env:
           NODE_ENV: "test"
       - name: Run tests

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "version": "10.1.1",
   "engines": {
-    "node": ">=20 <=24"
+    "node": ">=24"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Why

Maintaining compatibility with older Node versions has become too costly. Node 24 is the supported target going forward.

## Changes

- Update `engines.node` to `>=24`
- Narrow CI matrix to `24.x` only
- Remove `npm install -g npm@11.12.1` from CI (was causing failures due to a broken `promise-retry` dependency in npm@11.12.1 itself)