### PR TITLE
Bump major version to 11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "Markus Ekholm",
     "Ivan Malmberg"
   ],
-  "version": "10.1.1",
+  "version": "11.0.0",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
## Why

Dropping Node < 24 support (see #61) is a breaking change, requiring a major version bump.

## Changes

- `version`: `10.1.1` → `11.0.0`